### PR TITLE
Correct order of parameters for cliprect

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -28,10 +28,11 @@ NULL
 #'   are both unspecified, the clipping rectangle will contain the entire page.
 #'   This can be the string \code{"viewport"}, in which case the clipping
 #'   rectangle matches the viewport size, or it can be a four-element numeric
-#'   vector specifying the top, left, width, and height. When taking screenshots
-#'   of multiple URLs, this parameter can also be a list with same length as
-#'   \code{url} with each element of the list being "viewport" or a
-#'   four-elements numeric vector. This option is not compatible with
+#'   vector specifying the left, top, width, and height. (Note that the order of
+#'   left and top is reversed from the original webshot package.) When taking 
+#'   screenshots of multiple URLs, this parameter can also be a list with same 
+#'   length as \code{url} with each element of the list being "viewport" or a
+#'   four-elements numeric vector. This option is not compatible with 
 #'   \code{selector}.
 #' @param delay Time to wait before taking screenshot, in seconds. Sometimes a
 #'   longer delay is needed for all assets to display properly.


### PR DESCRIPTION
Great packages, thank you!

It seems that the order of the parameters of cliprect is not the same for webshot and webshot2:

Here top is clipped by 100:

`webshot::webshot("https://cran.r-project.org/", cliprect = c(100, 0, 300, 300), file = "webshot.png")`

![webshot](https://user-images.githubusercontent.com/14161912/70647546-2b082100-1c17-11ea-920d-87b9c7cb4b66.png)

Here left is clipped by 100:

`webshot2::webshot("https://cran.r-project.org/", cliprect = c(100, 0, 300, 300), file="webshot2.png")`

![webshot2](https://user-images.githubusercontent.com/14161912/70647568-38251000-1c17-11ea-9ac2-e1c7838ff53c.png)

I updated the documentation to reflect this difference.