### PR TITLE
Add resizing example

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -71,6 +71,10 @@ NULL
 #' webshot("http://rstudio.github.io/leaflet", "leaflet-viewport.png",
 #'         cliprect = "viewport")
 #'
+#' # Specific size
+#' webshot("https://www.r-project.org", vwidth = 1600, vheight = 900,
+#'         cliprect = "viewport")
+#'
 #' # Manual clipping rectangle
 #' webshot("http://rstudio.github.io/leaflet", "leaflet-clip.png",
 #'         cliprect = c(200, 5, 400, 300))

--- a/README.md
+++ b/README.md
@@ -25,4 +25,8 @@ webshot("https://www.r-project.org")
 
 # Multiple pages (in parallel!)
 webshot(c("https://www.r-project.org", "https://www.rstudio.com"))
+
+# Specific height and width
+webshot("https://www.r-project.org", vwidth = 1600, vheight = 900, cliprect = "viewport")
 ```
+

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -95,6 +95,10 @@ webshot(c("https://github.com/rstudio/shiny",
 webshot("http://rstudio.github.io/leaflet", "leaflet-viewport.png",
         cliprect = "viewport")
 
+# Specific size
+webshot("https://www.r-project.org", vwidth = 1600, vheight = 900,
+        cliprect = "viewport")
+
 # Manual clipping rectangle
 webshot("http://rstudio.github.io/leaflet", "leaflet-clip.png",
         cliprect = c(200, 5, 400, 300))


### PR DESCRIPTION
It wasn't clear to me right away that when you use `vheight` and `vwidth` you should also specify `cliprect = "viewport"` so I added an example about this to the README and also to the webshot help file.