### PR TITLE
Detect and forward errors from app creation

### DIFF
--- a/R/appshot.R
+++ b/R/appshot.R
@@ -71,12 +71,19 @@ appshot.character <- function(
     ),
     envvars = envvars
   )
+
   on.exit({
-    p$kill()
+    if (p$is_alive()) {
+      p$interrupt()
+      p$wait(2)
+      if (p$is_alive()) {
+        p$kill()
+      }
+    }
   })
 
   # Wait for app to start
-  wait_until_server_exists(url)
+  wait_until_server_exists(url, p)
 
   # Get screenshot
   fileout <- webshot(url, file = file, ...)
@@ -115,6 +122,7 @@ appshot.shiny.appobj <- function(
     args,
     envvars = envvars
   )
+
   on.exit({
     p$kill()
   })

--- a/R/wait.R
+++ b/R/wait.R
@@ -2,11 +2,16 @@ shiny_url <- function(port) {
   sprintf("http://127.0.0.1:%d/", port)
 }
 
-server_exists <- function(url) {
-  !inherits(
-    try({ suppressWarnings(readLines(url, 1)) }, silent = TRUE),
+server_exists <- function(url_id) {
+  # Using a url object instead of the url as a string because readLines() with
+  # url string will cause failed connections to stay open
+  url_obj <- url(url_id)
+  ret <- !inherits(
+    try({suppressWarnings(readLines(url_obj, 1))}, silent = TRUE),
     "try-error"
   )
+  close(url_obj)
+  ret
 }
 
 webshot_app_timeout <- function() {

--- a/R/wait.R
+++ b/R/wait.R
@@ -15,6 +15,7 @@ webshot_app_timeout <- function() {
 
 wait_until_server_exists <- function(
   url,
+  p,
   timeout = webshot_app_timeout()
 ) {
   cur_time <- function() {
@@ -31,6 +32,16 @@ wait_until_server_exists <- function(
         call. = FALSE
       )
     }
+
+    # Check if there was a failure in starting app server
+    if(!p$is_alive()){
+      stop(
+        "App has failed with error(s):\n",
+        paste(p$read_error_lines(), collapse = "\n"),
+        call. = FALSE
+      )
+    }
+
     Sys.sleep(0.25)
   }
 

--- a/R/wait.R
+++ b/R/wait.R
@@ -6,11 +6,12 @@ server_exists <- function(url_id) {
   # Using a url object instead of the url as a string because readLines() with
   # url string will cause failed connections to stay open
   url_obj <- url(url_id)
+  on.exit({close(url_obj)}, add = TRUE)
+
   ret <- !inherits(
     try({suppressWarnings(readLines(url_obj, 1))}, silent = TRUE),
     "try-error"
   )
-  close(url_obj)
   ret
 }
 


### PR DESCRIPTION
Previously, if there was an error in the app targeted by `appshot()` run in the background mode, the error would never surface and the server-exists checks would continue until timeout. This could (did) cause confusion about why an `appshot()` call was failing.

This PR now also checks for errors on the background process tasked with running the app in addition to checking for a response for the server. If an error is found then `appshot()` will error-out and forward the errors that the background process had to the user. 

There's also a commit (ac166f9) that switches to using a URL object instead of a character-string to test if the server exists. This is because repeatedly querying the same URL with a string causes a bunch of unclosed connections to open eventually causing the error `all connections in use`.  

```R
# Version 1
# Runs out of connections
for (i in 1:150) {
  try(readLines("http://localhost:1233/"))
}
# Clean up manually (not safe in general)
closeAllConnections()
# Version 2
# Does not run out of connections
for (i in 1:150) {
  url_obj <- url("http://localhost:1233/")
  try(readLines(url_obj))
  close(url_obj)
}
```

