### PR TITLE
Maybe a bug fix for lockups 

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -253,9 +253,8 @@ new_session_screenshot <- function(
       if (!is.null(useragent)) {
         s$Network$setUserAgentOverride(userAgent = useragent)
       }
-
-      s$Page$navigate(url, wait_ = FALSE)
-      s$Page$loadEventFired(wait_ = FALSE)
+      c(s$Page$navigate(url, wait_ = FALSE),
+        s$Page$loadEventFired(wait_ = FALSE))
     })$
     then(function(value) {
       if (delay > 0) {


### PR DESCRIPTION
In https://github.com/rstudio/chromote/issues/48 I described lockups that happen in `chromote` when using `webshot2`.  I narrowed the issue down to the section of code modified in this PR, and thought the code looked wrong.  This PR appears to fix the issue, but honestly I don't understand async programming well enough to know if it's right.

The idea is that one `then()` clause contained these two lines:

```
s$Page$navigate(url, wait_ = FALSE)
s$Page$loadEventFired(wait_ = FALSE)
```

which I suppose are both supposed to complete before we move on.  The change is to group them into one object using

```
c(s$Page$navigate(url, wait_ = FALSE),
    s$Page$loadEventFired(wait_ = FALSE))
```

in the hope that this makes `promises` wait for both to complete.  And it seems to work!