### PR TITLE
Fix lockup

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -253,9 +253,8 @@ new_session_screenshot <- function(
       if (!is.null(useragent)) {
         s$Network$setUserAgentOverride(userAgent = useragent)
       }
-
-      s$Page$navigate(url, wait_ = FALSE)
-      s$Page$loadEventFired(wait_ = FALSE)
+      c(s$Page$navigate(url, wait_ = FALSE),
+        s$Page$loadEventFired(wait_ = FALSE))
     })$
     then(function(value) {
       if (delay > 0) {

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -253,9 +253,9 @@ new_session_screenshot <- function(
       if (!is.null(useragent)) {
         s$Network$setUserAgentOverride(userAgent = useragent)
       }
-      promise_all(s$Page$loadEventFired(wait_ = FALSE),
-                  s$Page$navigate(url, wait_ = FALSE))
-
+      res <- s$Page$loadEventFired(wait_ = FALSE)
+      s$Page$navigate(url, wait_ = FALSE)
+      res
     })$
     then(function(value) {
       if (delay > 0) {

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -253,8 +253,9 @@ new_session_screenshot <- function(
       if (!is.null(useragent)) {
         s$Network$setUserAgentOverride(userAgent = useragent)
       }
-      c(s$Page$navigate(url, wait_ = FALSE),
-        s$Page$loadEventFired(wait_ = FALSE))
+      promise_all(s$Page$loadEventFired(wait_ = FALSE),
+                  s$Page$navigate(url, wait_ = FALSE))
+
     })$
     then(function(value) {
       if (delay > 0) {


### PR DESCRIPTION
This PR fixes the lockup described in https://github.com/rstudio/chromote/issues/48  when taking a webshot.  It puts the wait for the loadEvent in place before navigating to the page, but does it asynchronously.  I think when it was put in place after, it could be called too late, after the event had been missed.