### PR TITLE
fix: allows anchor links in local files

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -68,7 +68,7 @@ is_url <- function(x) {
 # Given the path to a file, return a file:// URL.
 file_url <- function(filename) {
   if (is_windows() & getRversion() < R_system_version("4.2.0")) {
-    enc2 <- identify
+    enc2 <- identity
   } else {
     enc2 <- enc2utf8
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,11 +76,7 @@ file_url <- function(filename) {
   anchor_suffix <- sub(file, "", filename)
   enc2(paste0(
     "file:///",
-    normalizePath(
-      path = file,
-      winslash = if (is_windows()) "\\" else "/",
-      mustWork = TRUE
-    ),
+    normalizePath(path = file, mustWork = TRUE),
     anchor_suffix
   ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,7 +78,7 @@ file_url <- function(filename) {
     "file:///",
     normalizePath(
       path = file,
-      winslash = c("/", "\\")[is_windows() + 1],
+      winslash = if (is_windows()) "\\" else "/",
       mustWork = TRUE
     ),
     anchor_suffix

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,19 +67,20 @@ is_url <- function(x) {
 
 # Given the path to a file, return a file:// URL.
 file_url <- function(filename) {
-  anchor_suffix <- sub("[^#]+(#*.*)$", "\\1", filename)
-  filename <- sub("#.*", "", filename)
-  if (is_windows()) {
-    paste0(
-      "file://",
-      normalizePath(filename, mustWork = TRUE),
-      anchor_suffix
-    )
+  if (is_windows() & getRversion() < R_system_version("4.2.0")) {
+    enc2 <- identify
   } else {
-    enc2utf8(paste0(
-      "file:///",
-      normalizePath(filename, winslash = "/", mustWork = TRUE),
-      anchor_suffix
-    ))
+    enc2 <- enc2utf8
   }
+  file <- sub("(.*)#[^#]*", "\\1", filename)
+  anchor_suffix <- sub(file, "", filename)
+  enc2(paste0(
+    "file:///",
+    normalizePath(
+      path = file,
+      winslash = c("/", "\\")[is_windows() + 1],
+      mustWork = TRUE
+    ),
+    anchor_suffix
+  ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,9 +67,19 @@ is_url <- function(x) {
 
 # Given the path to a file, return a file:// URL.
 file_url <- function(filename) {
+  anchor_suffix <- sub("[^#]+(#*.*)$", "\\1", filename)
+  filename <- sub("#.*", "", filename)
   if (is_windows()) {
-    paste0("file://", normalizePath(filename, mustWork = TRUE))
+    paste0(
+      "file://",
+      normalizePath(filename, mustWork = TRUE),
+      anchor_suffix
+    )
   } else {
-    enc2utf8(paste0("file:///", normalizePath(filename, winslash = "/", mustWork = TRUE)))
+    enc2utf8(paste0(
+      "file:///",
+      normalizePath(filename, winslash = "/", mustWork = TRUE),
+      anchor_suffix
+    ))
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,7 +67,7 @@ is_url <- function(x) {
 
 # Given the path to a file, return a file:// URL.
 file_url <- function(filename) {
-  if (is_windows() & getRversion() < R_system_version("4.2.0")) {
+  if (is_windows() && getRversion() < R_system_version("4.2.0")) {
     enc2 <- identity
   } else {
     enc2 <- enc2utf8


### PR DESCRIPTION
This PR allows: 

- to set an URL (based on a local file) containing anchor link, such as `directory/file.html#section-id`.  
  This was not possible since this is not a valid file per se.
- to use UTF-8, even on Windows, if R `4.2.0` or later is used.