### PR TITLE
Fix issues rendering shiny runtime Rmds from `rmdshot()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: webshot2
 Title: Take Screenshots of Web Pages
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
       person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),
       person("Barret", "Schloerke", role = c("ctb"), email = "barret@rstudio.com", comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# webshot2 (development version)
+
 # webshot2 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # webshot2 (development version)
 
+* Fixed `rmdshot()` when used to screenshot an R Markdown document with `runtime: shiny` or `runtime: shinyrmd` (#52).
+
 # webshot2 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/rmdshot.R
+++ b/R/rmdshot.R
@@ -64,9 +64,10 @@ rmdshot_shiny <- function(doc, file, ..., rmd_args, port, envvars) {
     function(...) {
       rmarkdown::run(...)
     },
-    args = append(
-      list(file = doc, shiny_args = list(port = port)),
-      rmd_args
+    args = list(
+      file = doc,
+      shiny_args = list(port = port),
+      render_args = rmd_args
     ),
     envvars = envvars
   )

--- a/R/rmdshot.R
+++ b/R/rmdshot.R
@@ -76,7 +76,7 @@ rmdshot_shiny <- function(doc, file, ..., rmd_args, port, envvars) {
   })
 
   # Wait for app to start
-  wait_until_server_exists(url)
+  wait_until_server_exists(url, p)
 
   fileout <- webshot(url, file = file, ...)
 


### PR DESCRIPTION
Fixes #52:

* Pass `rmd_args` to `rmarkdown::run(render_args =)`
* Pass `p` to `wait_until_server_exists()`, without which an error is thrown.