### PR TITLE
If the file contains backslashes, it will create an invalid file URL.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -76,7 +76,7 @@ file_url <- function(filename) {
   anchor_suffix <- sub(file, "", filename)
   enc2(paste0(
     "file:///",
-    normalizePath(path = file, mustWork = TRUE),
+    normalizePath(path = file, mustWork = TRUE, winslash = "/"),
     anchor_suffix
   ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,7 +73,7 @@ file_url <- function(filename) {
     enc2 <- enc2utf8
   }
   file <- sub("(.*)#[^#]*", "\\1", filename)
-  anchor_suffix <- sub(file, "", filename)
+  anchor_suffix <- sub(file, "", filename, fixed = TRUE)
   enc2(paste0(
     "file:///",
     normalizePath(path = file, mustWork = TRUE, winslash = "/"),


### PR DESCRIPTION
This issue https://github.com/dmurdoch/rgl/issues/391 was due to `webshot2::webshot` receiving `tempfile(ext = ".html")` as the `url` argument.  It recognized it as a file, and called `file_url(url)`, but didn't fix the backslashes, so it created an invalid URL.  This PR fixes that problem.