### PR TITLE
fix(webshot): Rethrow underlying chromote errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # webshot2 (development version)
 
+* `webshot()` now surfaces errors that occur when working with the lower-level screenshot API provided by Chrome via `{chromote}`. (#69)
+
 # webshot2 0.1.1
 
 * `webshot()` now supports JPEG (`.jpg` or `.jpeg`) and WEBP (`.webp`) image formats. (@trafficonese #45)

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -251,6 +251,7 @@ new_session_screenshot <- function(
 
 
   s <- NULL
+  err <- NULL
 
   p <- chromote$new_session(wait_ = FALSE,
       width = vwidth,
@@ -296,8 +297,14 @@ new_session_screenshot <- function(
       if (!isTRUE(quiet)) message(url, " screenshot completed")
       normalizePath(value)
     })$
+    catch(function(err) {
+      err <<- err
+    })$
     finally(function() {
-      s$close()
+      # Close down the session if we successfully started one
+      if (!is.null(s)) s$close()
+      # Or rethrow the error if we caught one
+      if (!is.null(err)) signalCondition(err)
     })
 
   p


### PR DESCRIPTION
For rstudio/chromote#183

Prior to this PR we could call `s$close()` even if `s` is `NULL` because the session wasn't started correctly. We also didn't have a `catch()` in the promise chain, which would cause `webshot()` to swallow uncaught errors.