### PR TITLE
fix: Set device width and height before screenshot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `webshot()` now surfaces errors that occur when working with the lower-level screenshot API provided by Chrome via `{chromote}`. (#69)
 
+* `webshot()` works harder to set the size of the virtual viewport when `vwidth` and `vheight` are used. This change improves compatibility with recent versions of Chrome (>= v132). (#72)
+
 # webshot2 0.1.1
 
 * `webshot()` now supports JPEG (`.jpg` or `.jpeg`) and WEBP (`.webp`) image formats. (@trafficonese #45)

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -329,7 +329,7 @@ new_session_screenshot <- function(
     })$
     finally(function() {
       # Close down the session if we successfully started one
-      # if (!is.null(s)) s$close()
+      if (!is.null(s)) s$close()
       # Or rethrow the error if we caught one
       if (!is.null(err)) signalCondition(err)
     })

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -274,6 +274,27 @@ new_session_screenshot <- function(
       res
     })$
     then(function(value) {
+      # With chrome's new headless mode (v132+), the new session is initialized,
+      # but our requested viewport size is ignored, so we set it explicitly.
+      promise(function(resolve, reject) {
+        s$Emulation$setDeviceMetricsOverride(
+          width = vwidth,
+          height = vheight,
+          deviceScaleFactor = 1,
+          mobile = FALSE,
+          wait_ = FALSE
+        )$then(function(result) {
+          resolve(result)
+        })
+      })$catch(function(error) {
+        warning(
+          "Could not set viewport size to ", vwidth, "x", vheight, ": ",
+          conditionMessage(error)
+        )
+        value
+      })
+    })$
+    then(function(value) {
       if (delay > 0) {
         promise(function(resolve, reject) {
           later(
@@ -308,7 +329,7 @@ new_session_screenshot <- function(
     })$
     finally(function() {
       # Close down the session if we successfully started one
-      if (!is.null(s)) s$close()
+      # if (!is.null(s)) s$close()
       # Or rethrow the error if we caught one
       if (!is.null(err)) signalCondition(err)
     })


### PR DESCRIPTION
We've noticed, e.g. in rstudio/chromote#197, that for Chrome's new headless mode (v132+), `ChromoteSession$new()` and `ChromoteSession$new_session()` with `width` and `height` don't actually set the viewport width and height.

This PR works around that limitation by calling `Emulation$setDeviceMetricsOverride()` before taking the screenshot.

Fixes rstudio/chromote#197