### PR TITLE
fix: Throw for non-numeric `vwidth` or `vheight` values

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-as_rounded_int <- function(x) {
+as_pixels_int <- function(x) {
   if (!is.numeric(x)) {
     x_name <- deparse(substitute(x))
     stop("`", x_name, "` must be an integer number of pixels, not '", x, "'.")
@@ -17,7 +17,6 @@ is_mac <- function() Sys.info()[["sysname"]] == "Darwin"
 is_linux <- function() Sys.info()[["sysname"]] == "Linux"
 
 
-
 # =============================================================================
 # Data manipulation
 # =============================================================================
@@ -26,8 +25,7 @@ is_linux <- function() Sys.info()[["sysname"]] == "Linux"
 # lists, each of which is a one-row "slice" of the input (like a D3 data
 # structure). The input list must be named, and the names must be unique.
 long_to_wide <- function(x) {
-  if (length(x) == 0)
-    return(x)
+  if (length(x) == 0) return(x)
 
   lapply(seq_along(x[[1]]), function(n) {
     lapply(stats::setNames(names(x), names(x)), function(name) {
@@ -55,7 +53,8 @@ available_port <- function(port = NULL, min = 3000, max = 9000) {
     # Check if port is open
     tryCatch(
       handle <- httpuv::startServer("127.0.0.1", port, list()),
-      error = function(e) { }
+      error = function(e) {
+      }
     )
     if (!is.null(handle)) {
       handle$stop()

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,7 @@ is_mac <- function() Sys.info()[["sysname"]] == "Darwin"
 is_linux <- function() Sys.info()[["sysname"]] == "Linux"
 
 
+
 # =============================================================================
 # Data manipulation
 # =============================================================================
@@ -30,7 +31,8 @@ is_linux <- function() Sys.info()[["sysname"]] == "Linux"
 # lists, each of which is a one-row "slice" of the input (like a D3 data
 # structure). The input list must be named, and the names must be unique.
 long_to_wide <- function(x) {
-  if (length(x) == 0) return(x)
+  if (length(x) == 0)
+    return(x)
 
   lapply(seq_along(x[[1]]), function(n) {
     lapply(stats::setNames(names(x), names(x)), function(name) {
@@ -58,8 +60,7 @@ available_port <- function(port = NULL, min = 3000, max = 9000) {
     # Check if port is open
     tryCatch(
       handle <- httpuv::startServer("127.0.0.1", port, list()),
-      error = function(e) {
-      }
+      error = function(e) { }
     )
     if (!is.null(handle)) {
       handle$stop()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 as_rounded_int <- function(x) {
-  x_name <- deparse(substitute(x))
   if (!is.numeric(x)) {
+    x_name <- deparse(substitute(x))
     stop("`", x_name, "` must be an integer number of pixels, not '", x, "'.")
   }
   if (inherits(x, "AsIs")) x else round(x, digits = 0)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,8 @@
 as_rounded_int <- function(x) {
+  x_name <- deparse(substitute(x))
+  if (!is.numeric(x)) {
+    stop("`", x_name, "` must be an integer number of pixels, not '", x, "'.")
+  }
   if (inherits(x, "AsIs")) x else round(x, digits = 0)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,9 +1,14 @@
 as_pixels_int <- function(x) {
+  if (inherits(x, "AsIs")) {
+    return(x)
+  }
+  
   if (!is.numeric(x)) {
     x_name <- deparse(substitute(x))
     stop("`", x_name, "` must be an integer number of pixels, not '", x, "'.")
   }
-  if (inherits(x, "AsIs")) x else round(x, digits = 0)
+  
+  round(x, digits = 0)
 }
 
 # =============================================================================

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -170,8 +170,8 @@ webshot <- function(
   args_all <- list(
     url       = url,
     file      = file,
-    vwidth    = as_rounded_int(vwidth), # Chrome requires integer viewport pxs
-    vheight   = as_rounded_int(vheight),
+    vwidth    = as_pixels_int(vwidth), # Chrome requires integer viewport pxs
+    vheight   = as_pixels_int(vheight),
     selector  = selector,
     cliprect  = cliprect,
     expand    = expand,


### PR DESCRIPTION
Fixes #74 

``` r
pkgload::load_all()
#> ℹ Loading webshot2

webshot2::webshot("https://posit.co", vwidth = "90%")
#> Error in as_rounded_int(vwidth): `vwidth` must be an integer number of pixels, not '90%'.
```