### PR TITLE
chore(license): Migrate GPL-2 license to MIT

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^man-roxygen$
 ^_dev$
 ^revdep$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
 Description: Takes screenshots of web pages, including Shiny applications
     and R Markdown documents. 'webshot2' uses headless Chrome or Chromium
     as the browser back-end.
-License: GPL-2
+License: MIT + file LICENSE
 URL: https://rstudio.github.io/webshot2/,
     https://github.com/rstudio/webshot2
 BugReports: https://github.com/rstudio/webshot2/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2025
+COPYRIGHT HOLDER: webshot2 authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 webshot2 authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # webshot2 (development version)
 
-* Migrate GPL-2 license to MIT ()
+* Migrate GPL-2 license to MIT (#79)
 
 * Updated the documentation for `webshot()` to clarify that `expand` only applies to the clipping rectangle determined by `selector`. (#68)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # webshot2 (development version)
 
+* Migrate GPL-2 license to MIT ()
+
 * Updated the documentation for `webshot()` to clarify that `expand` only applies to the clipping rectangle determined by `selector`. (#68)
 
 * `webshot()` now rounds `vwidth` and `vheight` to the nearest integer to match Chrome's expectations. If this behavior is somehow problematic, you can use `vwidth = I(my_width)` to avoid the conversion. (#70)


### PR DESCRIPTION
This pull request updates the licensing for the project, migrating from GPL-2 to the MIT license, and includes associated file changes. It also updates the `.Rbuildignore` file to exclude the new `LICENSE.md` file and documents the licensing change in `NEWS.md`.